### PR TITLE
Add PyCharm support. Ignore Trusted.Paths.Settings component in trusted-paths.xml

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,12 +9,19 @@ pub mod trusted_project {
 
     #[derive(Debug, Deserialize, PartialEq)]
     pub struct Component {
-        pub option: Option,
+        pub option: ComponentOption,
+        pub name: String
     }
 
     #[derive(Debug, Deserialize, PartialEq)]
-    pub struct Option {
-        pub map: Map,
+    pub struct ComponentOption {
+        pub map: Option<Map>,
+        #[serde(skip)]
+        pub list: Option<List>
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct List {
     }
 
     #[derive(Debug, Deserialize, PartialEq)]

--- a/src/jetbrains.rs
+++ b/src/jetbrains.rs
@@ -33,6 +33,7 @@ pub enum Ide {
     WebStorm,
     PhpStorm,
     Datagrip,
+    PyCharm
 }
 
 impl Ide {
@@ -45,6 +46,7 @@ impl Ide {
             Ide::WebStorm => "WebStorm",
             Ide::PhpStorm => "PhpStorm",
             Ide::Datagrip => "DataGrip",
+            Ide::PyCharm => "PyCharm"
         }
     }
 
@@ -57,6 +59,7 @@ impl Ide {
             Ide::WebStorm => "webstorm",
             Ide::PhpStorm => "phpstorm",
             Ide::Datagrip => "datagrip",
+            Ide::PyCharm => "pycharm"
         }
     }
 
@@ -69,6 +72,7 @@ impl Ide {
             Ide::WebStorm => "webstorm",
             Ide::PhpStorm => "phpstorm",
             Ide::Datagrip => "datagrip",
+            Ide::PyCharm => "datagrip",
         }
     }
 }
@@ -81,12 +85,13 @@ impl IdeConfigPath {
             let trusted_projects: Application = serde_xml_rs::from_str(&trusted_projects)?;
             let home = dirs::home_dir().expect("$HOME not found");
 
-            let components = trusted_projects
+            let entries = trusted_projects
                 .components
                 .into_iter()
-                .flat_map(|component| component.option.map.entries);
+                .filter(|component| component.name == "Trusted.Paths")
+                .flat_map(|component| component.option.map.unwrap().entries);
 
-            let projects = components
+            let projects = entries
                 .into_iter()
                 .map(|project| {
                     let path = project
@@ -151,6 +156,10 @@ impl TryFrom<PathBuf> for IdeConfigPath {
                     .map(|version| IdeConfigPath::new(path, ide, version))
             } else if filename.starts_with("DataGrip") {
                 let ide = Ide::Datagrip;
+                ide.parse_version(&path)
+                    .map(|version| IdeConfigPath::new(path, ide, version))
+    	    } else if filename.starts_with("PyCharm") {
+                let ide = Ide::PyCharm;
                 ide.parse_version(&path)
                     .map(|version| IdeConfigPath::new(path, ide, version))
             } else {

--- a/src/jetbrains.rs
+++ b/src/jetbrains.rs
@@ -72,7 +72,7 @@ impl Ide {
             Ide::WebStorm => "webstorm",
             Ide::PhpStorm => "phpstorm",
             Ide::Datagrip => "datagrip",
-            Ide::PyCharm => "datagrip",
+            Ide::PyCharm => "pycharm",
         }
     }
 }


### PR DESCRIPTION
Thanks for the plugin. I had been looking for this for a while, and considered making it myself. 

I tried to add PyCharm support, but that didn't work out of the box. After some debugging I found that I had a second <component> element in my trusted-paths.xml:

```
  <component name="Trusted.Paths.Settings">
    <option name="TRUSTED_PATHS">
      <list>
        <option value="$USER_HOME$/dir" />
      </list>
   </option>
</component
```
This extra component messed up parsing. So this PR also fixes that.

Two extra questions:

1. Why have you chosen to use trusted-paths.xml instead of recentProjects.xml? 
2. The icons don't work for me yet. Need to see what's wrong there.